### PR TITLE
corrected deprecated option

### DIFF
--- a/IPOPTtest.py
+++ b/IPOPTtest.py
@@ -85,7 +85,7 @@ print opt_prob
 ipopt = IPOPT()
 
 # Solve Problem with Optimizer Using Finite Differences
-ipopt.setOption('IFILE','ipopt.out')
+ipopt.setOption('output_file','ipopt.out')
 ipopt.setOption('max_iter',2)
 ipopt.setOption('linear_system_scaling','none')
 ipopt.setOption('tol',1e-2)


### PR DESCRIPTION
changed option: set IFILE to output_file (information about wanted option name generated by calling "ipopt --print-options")

old option generated the following error:

```
Tried to set Option: IFILE. It is not a valid option. Please check the list of available options.
Traceback (most recent call last):
  File "pyOpt-pyIPOPT/IPOPTtest.py", line 93, in <module>
    ipopt(opt_prob,sens_type='FD',store_hst=True)
  File "/home/rgiessmann/anaconda2/lib/python2.7/site-packages/pyOpt/pyOpt_optimizer.py", line 160, in __call__
    return self.__solve__(opt_problem, *args, **kwargs)
  File "/home/rgiessmann/anaconda2/lib/python2.7/site-packages/pyOpt/pyIPOPT/pyIPOPT.py", line 711, in __solve__
    ipopt.str_option(i,self.options[i][1])
ValueError: IFILE is not a valid string option
```
